### PR TITLE
0.138.0: Reconcile margin after risk-reducing order fills

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -887,7 +887,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "lfest"
-version = "0.137.3"
+version = "0.138.0"
 dependencies = [
  "assert2",
  "const-decimal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lfest"
-version = "0.137.3"
+version = "0.138.0"
 authors = ["MathisWellmann <wellmannmathis@gmail.com>"]
 edition = "2024"
 license-file = "LICENSE"

--- a/benches/order_book.rs
+++ b/benches/order_book.rs
@@ -18,7 +18,10 @@ use criterion::{
     criterion_group,
     criterion_main,
 };
-use lfest::prelude::*;
+use lfest::{
+    prelude::*,
+    test_fee_maker,
+};
 use rand::{
     Rng,
     SeedableRng,
@@ -47,6 +50,8 @@ fn criterion_benchmark(c: &mut Criterion) {
                     Account::new(
                         Balances::new(QuoteCurrency::new(1000, 0)),
                         NonZeroU16::new(n as u16).unwrap(),
+                        const_decimal::Decimal::ONE,
+                        *test_fee_maker().as_ref(),
                     )
                 },
                 |mut ob| {

--- a/benches/order_margin.rs
+++ b/benches/order_margin.rs
@@ -17,7 +17,10 @@ use criterion::{
     criterion_group,
     criterion_main,
 };
-use lfest::prelude::*;
+use lfest::{
+    prelude::*,
+    test_fee_maker,
+};
 
 fn criterion_benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("OrderMargin");
@@ -42,6 +45,8 @@ fn criterion_benchmark(c: &mut Criterion) {
                     Account::new(
                         Balances::new(QuoteCurrency::new(1_000_000, 0)),
                         max_active_orders,
+                        const_decimal::Decimal::ONE,
+                        *test_fee_maker().as_ref(),
                     )
                 },
                 |mut account| {
@@ -64,6 +69,8 @@ fn criterion_benchmark(c: &mut Criterion) {
                     let mut account = Account::new(
                         Balances::new(QuoteCurrency::new(1_000_000, 0)),
                         max_active_orders,
+                        const_decimal::Decimal::ONE,
+                        *test_fee_maker().as_ref(),
                     );
                     for order in orders.iter() {
                         account.try_insert_order(order.clone()).expect("Can insert");
@@ -94,6 +101,8 @@ fn criterion_benchmark(c: &mut Criterion) {
                     let mut account = Account::new(
                         Balances::new(QuoteCurrency::new(1_000_000, 0)),
                         max_active_orders,
+                        const_decimal::Decimal::ONE,
+                        *test_fee_maker().as_ref(),
                     );
                     for order in orders.iter() {
                         account.try_insert_order(black_box(order.clone())).unwrap()
@@ -119,6 +128,8 @@ fn criterion_benchmark(c: &mut Criterion) {
                     let mut account = Account::new(
                         Balances::new(QuoteCurrency::new(1_000_000, 0)),
                         max_active_orders,
+                        const_decimal::Decimal::ONE,
+                        *test_fee_maker().as_ref(),
                     );
                     for order in orders.iter() {
                         account.try_insert_order(black_box(order.clone())).unwrap()
@@ -140,6 +151,8 @@ fn criterion_benchmark(c: &mut Criterion) {
                     let mut account = Account::new(
                         Balances::new(QuoteCurrency::new(1_000_000, 0)),
                         max_active_orders,
+                        const_decimal::Decimal::ONE,
+                        *test_fee_maker().as_ref(),
                     );
                     for order in orders.iter() {
                         account.try_insert_order(black_box(order.clone())).unwrap()
@@ -161,6 +174,8 @@ fn criterion_benchmark(c: &mut Criterion) {
                     let mut account = Account::new(
                         Balances::new(QuoteCurrency::new(1_000_000, 0)),
                         max_active_orders,
+                        const_decimal::Decimal::ONE,
+                        *test_fee_maker().as_ref(),
                     );
                     for order in orders.iter() {
                         account.try_insert_order(black_box(order.clone())).unwrap()

--- a/src/account/account_impl.rs
+++ b/src/account/account_impl.rs
@@ -18,6 +18,7 @@ use crate::{
         MarginCurrency,
         MaxNumberOfActiveOrders,
         Mon,
+        OrderId,
         OrderIdNotFound,
         Pending,
         QuoteCurrency,
@@ -53,6 +54,9 @@ where
     /// The initial margin requirement is set based on the selected leverage of the account.
     init_margin_req: Decimal<I, D>,
 
+    /// The maker fee rate of the venue, used to reserve fees for resting limit orders.
+    maker_fee: Decimal<I, D>,
+
     /// The active limit orders of the account.
     #[getset(get = "pub")]
     active_limit_orders: ActiveLimitOrders<I, D, BaseOrQuote, UserOrderIdT>,
@@ -66,25 +70,93 @@ where
     UserOrderIdT: UserOrderId,
 {
     /// Create a new instance with a maximum capacity of `max_active_orders`.
+    ///
+    /// `init_margin_req` is the initial margin requirement derived from the configured
+    /// leverage and `maker_fee` is the venue's maker fee rate, both of which enter the
+    /// canonical collateral requirement of the account.
     pub fn new(
         balances: Balances<I, D, BaseOrQuote::PairedCurrency>,
         max_active_orders: NonZeroU16,
+        init_margin_req: Decimal<I, D>,
+        maker_fee: Decimal<I, D>,
     ) -> Self {
+        assert2::assert!(init_margin_req > Decimal::zero());
+        assert2::assert!(init_margin_req <= Decimal::ONE);
         Self {
             active_limit_orders: ActiveLimitOrders::with_capacity(max_active_orders),
             position: Position::default(),
             balances,
-            init_margin_req: Decimal::ONE, // 1x leverage by default.
+            init_margin_req,
+            maker_fee,
         }
     }
 
-    /// The available balance is the account equity minus position and order margin.
+    /// The maker fees reserved for the resting limit orders, so that any of their fills
+    /// can always be paid for. A negative (rebate) maker fee reserves nothing.
+    #[inline(always)]
+    #[must_use]
+    pub fn reserved_maker_fees(&self) -> BaseOrQuote::PairedCurrency {
+        (self.active_limit_orders.bids().notional_sum()
+            + self.active_limit_orders.asks().notional_sum())
+            * self.maker_fee.max(Decimal::zero())
+    }
+
+    /// The canonical collateral requirement of the account:
+    /// the position margin, the order margin and the reserved maker fees.
+    ///
+    /// Both order admission in the risk engine and the exchange's post-fill margin
+    /// reconciliation are based on this single requirement.
+    #[inline(always)]
+    #[must_use]
+    pub fn required_collateral(&self) -> BaseOrQuote::PairedCurrency {
+        self.position_margin() + self.order_margin() + self.reserved_maker_fees()
+    }
+
+    /// The signed difference between the account equity and its required collateral.
+    ///
+    /// A negative value is a collateral deficit: it can arise from settling a
+    /// position-reducing fill (which is never rejected) and is resolved by the
+    /// exchange's margin call, which force-cancels resting limit orders.
+    #[inline(always)]
+    #[must_use]
+    pub fn margin_excess(&self) -> BaseOrQuote::PairedCurrency {
+        self.balances.equity() - self.required_collateral()
+    }
+
+    /// The balance available for new orders and positions:
+    /// the account equity exceeding the required collateral, floored at zero.
     #[inline(always)]
     #[must_use]
     pub fn available_balance(&self) -> BaseOrQuote::PairedCurrency {
-        let avail = self.balances.equity() - self.position_margin() - self.order_margin();
-        debug_assert!(avail >= Zero::zero());
-        avail
+        self.margin_excess().max(Zero::zero())
+    }
+
+    /// The id of the resting order whose cancellation frees the most collateral;
+    /// see `ActiveLimitOrders::largest_collateral_contributor`.
+    #[inline(always)]
+    #[must_use]
+    pub(crate) fn largest_collateral_contributor(&self) -> Option<OrderId> {
+        self.active_limit_orders.largest_collateral_contributor(
+            self.init_margin_req,
+            &self.position,
+            self.maker_fee,
+        )
+    }
+
+    /// The margin excess if `new_order` were also resting,
+    /// including its order margin and maker fee reserve.
+    #[inline(always)]
+    #[must_use]
+    pub(crate) fn margin_excess_with_order(
+        &self,
+        new_order: &LimitOrder<I, D, BaseOrQuote, UserOrderIdT, Pending<I, D, BaseOrQuote>>,
+    ) -> BaseOrQuote::PairedCurrency {
+        let new_fee_reserve = new_order.notional() * self.maker_fee.max(Decimal::zero());
+        self.balances.equity()
+            - self.position_margin()
+            - self.order_margin_with_order(new_order)
+            - self.reserved_maker_fees()
+            - new_fee_reserve
     }
 
     /// The current position margin

--- a/src/account/active_limit_orders.rs
+++ b/src/account/active_limit_orders.rs
@@ -149,6 +149,39 @@ where
         )
     }
 
+    /// The id of the resting order whose cancellation frees the most collateral:
+    /// the largest marginal contributor of order margin plus reserved maker fee.
+    ///
+    /// The marginal contribution is computed with the same canonical
+    /// [`order_margin`] function which admission is based on, so the margin call
+    /// of the exchange and the risk engine can never disagree.
+    #[must_use]
+    pub(crate) fn largest_collateral_contributor(
+        &self,
+        init_margin_req: Decimal<I, D>,
+        position: &Position<I, D, BaseOrQuote>,
+        maker_fee: Decimal<I, D>,
+    ) -> Option<OrderId> {
+        let bids_notional = self.bids.notional_sum();
+        let asks_notional = self.asks.notional_sum();
+        let current_margin = order_margin(bids_notional, asks_notional, init_margin_req, position);
+        let fee = maker_fee.max(Decimal::zero());
+
+        let marginal_collateral =
+            |order: &LimitOrder<I, D, BaseOrQuote, UserOrderIdT, Pending<I, D, BaseOrQuote>>| {
+                let (bids, asks) = match order.side() {
+                    Buy => (bids_notional - order.notional(), asks_notional),
+                    Sell => (bids_notional, asks_notional - order.notional()),
+                };
+                let margin_without = order_margin(bids, asks, init_margin_req, position);
+                current_margin - margin_without + order.notional() * fee
+            };
+
+        self.iter()
+            .max_by_key(|order| marginal_collateral(order))
+            .map(|order| order.id())
+    }
+
     /// Get the order margin if a new order were to be added.
     #[must_use]
     pub(crate) fn order_margin_with_order(

--- a/src/account/balances.rs
+++ b/src/account/balances.rs
@@ -25,6 +25,13 @@ where
     #[getset(get_copy = "pub")]
     total_fees_paid: BaseOrQuote,
 
+    /// The cumulative losses which exceeded the account equity and were absorbed by the
+    /// venue (insurance fund / auto-deleveraging on a real exchange).
+    /// Non-zero bad debt means the account went bankrupt; its equity is floored at zero.
+    #[getset(get_copy = "pub")]
+    #[builder(default)]
+    bad_debt: BaseOrQuote,
+
     /// A marker type.
     #[builder(default)]
     _i: PhantomData<I>,
@@ -38,8 +45,8 @@ where
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "equity: {}, total_fees_paid: {}",
-            self.equity, self.total_fees_paid,
+            "equity: {}, total_fees_paid: {}, bad_debt: {}",
+            self.equity, self.total_fees_paid, self.bad_debt,
         )
     }
 }
@@ -54,6 +61,7 @@ where
         Self {
             equity: init_balance,
             total_fees_paid: BaseOrQuote::zero(),
+            bad_debt: BaseOrQuote::zero(),
             _i: PhantomData,
         }
     }
@@ -64,22 +72,43 @@ where
     }
 
     /// If `fee` is negative then we receive balance.
+    /// A fee exceeding the equity bankrupts the account; see `Balances::apply_to_equity`.
     #[inline(always)]
     pub fn account_for_fee(&mut self, fee: BaseOrQuote) {
         self.debug_assert_state();
 
-        self.equity -= fee;
-        assert2::debug_assert!(self.equity >= BaseOrQuote::zero());
-
+        self.apply_to_equity(-fee);
         self.total_fees_paid += fee;
     }
 
     /// Profit and loss are applied to the available balance.
+    /// A loss exceeding the equity bankrupts the account; see `Balances::apply_to_equity`.
     #[inline(always)]
     pub fn apply_pnl(&mut self, pnl: BaseOrQuote) {
         trace!("apply_pnl: {pnl}");
-        self.equity += pnl;
-        assert2::debug_assert!(self.equity >= BaseOrQuote::zero());
+        self.apply_to_equity(pnl);
+    }
+
+    /// Apply a signed equity change from a realized pnl or fee.
+    ///
+    /// A change which would push the equity below zero bankrupts the account:
+    /// a real venue absorbs the excess loss (insurance fund / auto-deleveraging)
+    /// rather than collecting it from the trader, so the excess is recorded as
+    /// [`Balances::bad_debt`] and the equity is floored at zero.
+    #[inline(always)]
+    fn apply_to_equity(&mut self, delta: BaseOrQuote) {
+        let new_equity = self.equity + delta;
+        if new_equity < BaseOrQuote::zero() {
+            core::hint::cold_path();
+            tracing::warn!(
+                "account is bankrupt: the venue absorbs {} of bad debt",
+                -new_equity
+            );
+            self.bad_debt -= new_equity;
+            self.equity = BaseOrQuote::zero();
+        } else {
+            self.equity = new_equity;
+        }
     }
 }
 
@@ -96,8 +125,8 @@ mod test {
 
     #[test]
     fn size_of_balances() {
-        assert_eq!(size_of::<Balances<i32, 5, BaseCurrency<i32, 5>>>(), 8);
-        assert_eq!(size_of::<Balances<i64, 5, BaseCurrency<i64, 5>>>(), 16);
+        assert_eq!(size_of::<Balances<i32, 5, BaseCurrency<i32, 5>>>(), 12);
+        assert_eq!(size_of::<Balances<i64, 5, BaseCurrency<i64, 5>>>(), 24);
     }
 
     proptest! {
@@ -112,6 +141,7 @@ mod test {
                 .total_fees_paid(fee)
                 .build()
             );
+            assert!(balances.bad_debt().is_zero());
         }
     }
 
@@ -126,6 +156,21 @@ mod test {
     }
 
     #[test]
+    fn bankrupting_loss_is_recorded_as_bad_debt() {
+        let mut balances = Balances::new(QuoteCurrency::<i64, 5>::new(100, 0));
+        balances.apply_pnl(QuoteCurrency::new(-150, 0));
+        assert!(balances.equity().is_zero());
+        assert_eq!(balances.bad_debt(), QuoteCurrency::new(50, 0));
+        balances.debug_assert_state();
+
+        let mut balances = Balances::new(QuoteCurrency::<i64, 5>::new(100, 0));
+        balances.account_for_fee(QuoteCurrency::new(101, 0));
+        assert!(balances.equity().is_zero());
+        assert_eq!(balances.bad_debt(), QuoteCurrency::new(1, 0));
+        assert_eq!(balances.total_fees_paid(), QuoteCurrency::new(101, 0));
+    }
+
+    #[test]
     fn balances_display() {
         let balances = Balances::builder()
             .equity(QuoteCurrency::<i64, 5>::new(1000, 0))
@@ -133,7 +178,7 @@ mod test {
             .build();
         assert_eq!(
             balances.to_string(),
-            "equity: 1000.00000 Quote, total_fees_paid: 5.00000 Quote"
+            "equity: 1000.00000 Quote, total_fees_paid: 5.00000 Quote, bad_debt: 0.00000 Quote"
         );
     }
 }

--- a/src/exchange.rs
+++ b/src/exchange.rs
@@ -38,6 +38,7 @@ use crate::{
         ExchangeOrderMeta,
         Filled,
         LimitOrder,
+        LimitOrderEvent,
         LimitOrderFill,
         MarginCurrency,
         MarketOrder,
@@ -47,12 +48,38 @@ use crate::{
         Pending,
         RiskError,
         Side::*,
+        Solvency,
         SubmitLimitOrderError,
         SubmitMarketOrderError,
         TimestampNs,
         UserOrderId,
     },
 };
+
+/// The resting limit orders which the venue force-cancelled to keep the account's
+/// required collateral covered by its equity (margin call).
+pub type ForcedCancels<I, const D: u8, BaseOrQuote, UserOrderIdT> =
+    Vec<LimitOrder<I, D, BaseOrQuote, UserOrderIdT, Pending<I, D, BaseOrQuote>>>;
+
+/// The result of a settled market order: the fill itself together with every side effect
+/// of settling it, emitted atomically so the caller cannot miss account-changing events.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct MarketOrderSettlement<I, const D: u8, BaseOrQuote, UserOrderIdT>
+where
+    I: Mon<D>,
+    BaseOrQuote: Currency<I, D>,
+    BaseOrQuote::PairedCurrency: MarginCurrency<I, D>,
+    UserOrderIdT: UserOrderId,
+{
+    /// The market order in its filled state.
+    pub filled_order: MarketOrder<I, D, BaseOrQuote, UserOrderIdT, Filled<I, D, BaseOrQuote>>,
+    /// The resting limit orders the venue force-cancelled to keep the account's required
+    /// collateral covered after this fill (margin call).
+    /// Empty unless the fill reduced or closed the position.
+    pub forced_cancels: ForcedCancels<I, D, BaseOrQuote, UserOrderIdT>,
+    /// The solvency of the account after settlement and collateral reconciliation.
+    pub solvency: Solvency,
+}
 
 /// The main leveraged futures exchange for simulated trading
 #[derive(Debug, Clone, Getters, MutGetters)]
@@ -79,8 +106,23 @@ where
     #[getset(get = "pub")]
     account: Account<I, D, BaseOrQuote, UserOrderIdT>,
 
-    // To avoid allocations in hot-paths
-    limit_order_updates: Vec<LimitOrderFill<I, D, BaseOrQuote, UserOrderIdT>>,
+    /// The limit order events (fills and forced cancellations) of the most recent
+    /// [`Exchange::update_state`] call, in occurrence order.
+    ///
+    /// This getter matters after `update_state` returned `Err(RiskError::Liquidate)`:
+    /// the error return cannot hand out the events, yet a liquidation force-cancels
+    /// every resting order and those cancellations are recorded here.
+    // Buffer kept to avoid allocations in hot-paths.
+    #[getset(get = "pub")]
+    limit_order_events: Vec<LimitOrderEvent<I, D, BaseOrQuote, UserOrderIdT>>,
+
+    /// Scratch buffer collecting force-cancelled orders during a collateral
+    /// reconciliation, routed into `limit_order_events` or a `MarketOrderSettlement`.
+    forced_cancel_scratch: ForcedCancels<I, D, BaseOrQuote, UserOrderIdT>,
+
+    /// Whether a fill-triggered reconciliation liquidated or bankrupted the account
+    /// during the current `update_state` call.
+    liquidated_during_fills: bool,
 
     order_rate_limiter: OrderRateLimiter,
 }
@@ -102,32 +144,47 @@ where
         let order_rate_limiter =
             OrderRateLimiter::new(config.order_rate_limits().orders_per_second());
         let balances = Balances::new(config.starting_wallet_balance());
+        let init_margin_req = config.contract_spec().init_margin_req();
+        let maker_fee = *config.contract_spec().fee_maker().as_ref();
         Self {
             config,
             market_state,
             risk_engine,
             next_order_id: OrderId::default(),
-            account: Account::new(balances, max_active_orders),
-            limit_order_updates: Vec::with_capacity(max_active_orders.get().into()),
+            account: Account::new(balances, max_active_orders, init_margin_req, maker_fee),
+            // Bids and asks each have a capacity of `max_active_orders`, so one update
+            // can emit at most `2 * max_active_orders` fills plus as many forced cancels.
+            limit_order_events: Vec::with_capacity(usize::from(max_active_orders.get()) * 4),
+            forced_cancel_scratch: Vec::with_capacity(usize::from(max_active_orders.get()) * 2),
+            liquidated_during_fills: false,
             order_rate_limiter,
         }
     }
 
     /// Update the exchange state with new information
-    /// Returns a reference to order updates vector for performance reasons.
+    /// Returns a reference to the event vector for performance reasons.
     ///
     /// ### Parameters:
     /// `market_update`: Newest market information
     ///
     /// ### Returns:
-    /// If Ok, returns updates regarding limit orders, wether partially filled or fully.
+    /// If Ok, the limit order events of this update in occurrence order: partial and full
+    /// fills as well as resting orders the venue force-cancelled to keep the account's
+    /// required collateral covered (margin call).
+    /// `Err(RiskError::Liquidate)` means the position was force-closed, either because
+    /// the market crossed its liquidation price or because a fill left the equity below
+    /// the maintenance margin; the accompanying forced cancellations are then available
+    /// through [`Exchange::limit_order_events`].
     pub fn update_state<U>(
         &mut self,
         market_update: &U,
-    ) -> Result<&Vec<LimitOrderFill<I, D, BaseOrQuote, UserOrderIdT>>, RiskError>
+    ) -> Result<&Vec<LimitOrderEvent<I, D, BaseOrQuote, UserOrderIdT>>, RiskError>
     where
         U: MarketUpdate<I, D, BaseOrQuote>,
     {
+        self.limit_order_events.clear();
+        self.liquidated_during_fills = false;
+
         self.market_state
             .update_state(market_update, self.config.contract_spec().price_filter());
 
@@ -142,12 +199,17 @@ where
             self.account.position(),
         ) {
             core::hint::cold_path();
-            self.liquidate();
+            self.force_liquidate();
+            self.drain_forced_cancels_into_events();
             return Err(e);
         };
 
         self.check_active_orders(market_update.clone());
-        Ok(&self.limit_order_updates)
+        if self.liquidated_during_fills {
+            core::hint::cold_path();
+            return Err(RiskError::Liquidate);
+        }
+        Ok(&self.limit_order_events)
     }
 
     /// Set the best bid and ask, alternatively a `Bba` `MarketUpdate` can be passed into `update_state`
@@ -158,45 +220,155 @@ where
         self.market_state.set_ask(ask);
     }
 
-    // Liquidate the position by closing it with a market order.
-    fn liquidate(&mut self) {
+    /// Force-close the position like a real venue's liquidation engine:
+    /// first cancel every resting limit order of the account (buffering them in the
+    /// forced-cancel scratch), then close the position with an internal fill at the
+    /// current bid or ask.
+    ///
+    /// This deliberately bypasses the order rate limiter and every admission check,
+    /// because a forced liquidation must never fail. A realized loss exceeding the
+    /// account equity is absorbed by the venue as `Balances::bad_debt`, so this
+    /// method cannot panic on bankrupting fills either.
+    fn force_liquidate(&mut self) {
         warn!("liquidating position {}", self.account.position());
         assert2::debug_assert!(self.market_state.ask() > QuoteCurrency::zero());
         assert2::debug_assert!(self.market_state.bid() > QuoteCurrency::zero());
-        if self.account.position().quantity().is_zero() {
-            core::hint::cold_path();
-            panic!("A neutral position can not be liquidated")
-        }
-        let order = {
-            let side = if self.account().position().quantity().is_negative() {
-                Buy
-            } else {
-                Sell
-            };
-            MarketOrder::new(side, self.account.position().quantity().abs())
-                .expect("Can create market order.")
-        };
+        assert2::debug_assert!(
+            !self.account.position().quantity().is_zero(),
+            "A neutral position can not be liquidated"
+        );
 
-        self.submit_market_order(order)
-            .expect("Must be able to submit liquidation order");
+        loop {
+            let Some(order_id) = self
+                .account
+                .active_limit_orders()
+                .iter()
+                .next()
+                .map(|order| order.id())
+            else {
+                break;
+            };
+            let cancelled = self
+                .account
+                .cancel_limit_order(CancelBy::OrderId(order_id))
+                .expect("the id belongs to an active order");
+            self.forced_cancel_scratch
+                .push_within_capacity(cancelled)
+                .expect(EXPECT_CAPACITY);
+        }
+
+        let position_qty = self.account.position().quantity();
+        let (side, fill_price) = if position_qty.is_negative() {
+            (Buy, self.market_state.ask())
+        } else {
+            (Sell, self.market_state.bid())
+        };
+        let quantity = position_qty.abs();
+        let notional = BaseOrQuote::PairedCurrency::convert_from(quantity, fill_price);
+        let fee = notional * *self.config.contract_spec().fee_taker().as_ref();
+        self.account
+            .change_position(quantity, fill_price, side, fee);
         info!("balances after liquidation: {}", self.account.balances());
     }
 
+    /// Reconcile the account collateral after a fill was settled.
+    ///
+    /// Position-reducing fills are never rejected by the venue, so settling one can leave
+    /// the account equity below the canonical requirement (`Account::required_collateral`):
+    /// the fill pays fees, may realize a loss and shrinks the position notional which
+    /// offset resting reduce-side limit orders. Mirroring a real venue, the exchange then:
+    ///
+    /// 1. force-closes the position if its maintenance margin is no longer covered by the
+    ///    equity (complementing the price-based liquidation check in `update_state`);
+    /// 2. force-cancels resting limit orders - largest collateral contributor first, so as
+    ///    few orders as possible are cancelled - until the requirement is covered again;
+    /// 3. reports the resulting [`Solvency`], where `bad_debt_before` is the reference
+    ///    point deciding whether this settlement bankrupted the account.
+    ///
+    /// The cancelled orders are buffered in the forced-cancel scratch, which the caller
+    /// routes into its atomic result (a [`MarketOrderSettlement`] or the event stream).
+    #[must_use]
+    fn reconcile_margin(&mut self, bad_debt_before: BaseOrQuote::PairedCurrency) -> Solvency {
+        let maintenance_margin_req = self.config.contract_spec().maintenance_margin();
+        let liquidated = if !self.account.position().quantity().is_zero()
+            && self.account.balances().equity()
+                < self.account.position().notional() * maintenance_margin_req
+        {
+            core::hint::cold_path();
+            self.force_liquidate();
+            true
+        } else {
+            false
+        };
+
+        while self.account.margin_excess() < Zero::zero() {
+            core::hint::cold_path();
+            let Some(victim_id) = self.account.largest_collateral_contributor() else {
+                // No resting orders remain; the equity is below the position's initial
+                // margin requirement but still covers its maintenance margin. The account
+                // may not increase its risk (the available balance is zero) but keeps the
+                // position.
+                break;
+            };
+            let cancelled = self
+                .account
+                .cancel_limit_order(CancelBy::OrderId(victim_id))
+                .expect("the id belongs to an active order which was just looked up");
+            warn!(
+                "margin call: force-cancelling limit order {} to cover the required collateral",
+                cancelled.id()
+            );
+            self.forced_cancel_scratch
+                .push_within_capacity(cancelled)
+                .expect(EXPECT_CAPACITY);
+        }
+
+        if self.account.balances().bad_debt() > bad_debt_before {
+            core::hint::cold_path();
+            Solvency::Bankrupt
+        } else if liquidated {
+            core::hint::cold_path();
+            Solvency::Liquidated
+        } else if self.account.margin_excess() < Zero::zero() {
+            core::hint::cold_path();
+            Solvency::InitialMarginDeficit
+        } else {
+            Solvency::Solvent
+        }
+    }
+
+    /// Route the forced cancellations of a reconciliation into the event stream of
+    /// [`Exchange::update_state`], preserving their order.
+    fn drain_forced_cancels_into_events(&mut self) {
+        for i in 0..self.forced_cancel_scratch.len() {
+            self.limit_order_events
+                .push_within_capacity(LimitOrderEvent::ForcedCancel(
+                    self.forced_cancel_scratch[i].clone(),
+                ))
+                .expect(EXPECT_CAPACITY);
+        }
+        self.forced_cancel_scratch.clear();
+    }
+
     /// Submit a new `MarketOrder` to the exchange.
+    ///
+    /// A position-reducing order is never rejected for balance reasons; any collateral
+    /// shortfall its settlement causes is reconciled by the venue's margin call and
+    /// reported in the returned [`MarketOrderSettlement`].
     ///
     /// # Arguments:
     /// `order`: The order that is being submitted.
     ///
     /// # Returns:
-    /// If Ok, the order with timestamp and id filled in.
+    /// If Ok, the settlement of the immediately filled order: the fill itself, the
+    /// resting limit orders the venue force-cancelled because of it and the resulting
+    /// account [`Solvency`].
     /// Else its an error.
     pub fn submit_market_order(
         &mut self,
         order: MarketOrder<I, D, BaseOrQuote, UserOrderIdT, NewOrder>,
-    ) -> Result<
-        MarketOrder<I, D, BaseOrQuote, UserOrderIdT, Filled<I, D, BaseOrQuote>>,
-        SubmitMarketOrderError,
-    > {
+    ) -> Result<MarketOrderSettlement<I, D, BaseOrQuote, UserOrderIdT>, SubmitMarketOrderError>
+    {
         self.order_rate_limiter
             .aquire(self.market_state.current_ts_ns())?;
         // Basic checks
@@ -221,15 +393,21 @@ where
             .check_market_order(&self.account, &order, fill_price)?;
 
         let filled_order = order.into_filled(fill_price, self.market_state.current_timestamp_ns());
-        self.settle_filled_market_order(filled_order.clone());
+        let (forced_cancels, solvency) = self.settle_filled_market_order(filled_order.clone());
 
-        Ok(filled_order)
+        Ok(MarketOrderSettlement {
+            filled_order,
+            forced_cancels,
+            solvency,
+        })
     }
 
+    /// Settle an immediately filled market order and reconcile the account collateral,
+    /// returning the forced cancellations and the resulting solvency.
     fn settle_filled_market_order(
         &mut self,
         order: MarketOrder<I, D, BaseOrQuote, UserOrderIdT, Filled<I, D, BaseOrQuote>>,
-    ) {
+    ) -> (ForcedCancels<I, D, BaseOrQuote, UserOrderIdT>, Solvency) {
         let filled_qty = order.quantity();
         assert2::debug_assert!(filled_qty > BaseOrQuote::zero());
         let fill_price = order.state().avg_fill_price();
@@ -238,8 +416,22 @@ where
         let notional = BaseOrQuote::PairedCurrency::convert_from(filled_qty, fill_price);
         let fee = notional * *self.config.contract_spec().fee_taker().as_ref();
 
+        let bad_debt_before = self.account.balances().bad_debt();
         self.account
             .change_position(filled_qty, fill_price, order.side(), fee);
+
+        // A position-reducing fill settles without a prior risk check; the venue
+        // reconciles any collateral shortfall instead of rejecting the reduction.
+        let solvency = self.reconcile_margin(bad_debt_before);
+        // Move the cancelled orders out while retaining the scratch buffer's capacity,
+        // which `push_within_capacity` relies on. Allocation-free when empty.
+        let mut forced_cancels = ForcedCancels::with_capacity(self.forced_cancel_scratch.len());
+        for order in self.forced_cancel_scratch.drain(..) {
+            forced_cancels
+                .push_within_capacity(order)
+                .expect(EXPECT_CAPACITY);
+        }
+        (forced_cancels, solvency)
     }
 
     #[inline(always)]
@@ -425,8 +617,8 @@ where
     where
         U: MarketUpdate<I, D, BaseOrQuote>,
     {
-        // Clear any potential order updates from the previous iteration.
-        self.limit_order_updates.clear();
+        // Clear any potential order events from the previous iteration.
+        self.limit_order_events.clear();
 
         if !U::CAN_FILL_LIMIT_ORDERS {
             return;
@@ -436,14 +628,24 @@ where
             // peek at the best bid order.
             while let Some(order) = self.account.active_limit_orders().best_bid() {
                 if let Some((filled_qty, exhausted)) = market_update.limit_order_filled(order) {
+                    let bad_debt_before = self.account.balances().bad_debt();
                     let limit_order_update = self.fill_limit_order(
                         order.clone(),
                         filled_qty,
                         market_update.timestamp_exchange_ns(),
                     );
-                    self.limit_order_updates
-                        .push_within_capacity(limit_order_update)
+                    self.limit_order_events
+                        .push_within_capacity(LimitOrderEvent::Fill(limit_order_update))
                         .expect(EXPECT_CAPACITY);
+                    // A fill which reduced the position settles without a prior risk
+                    // check; the venue reconciles any collateral shortfall it caused.
+                    let solvency = self.reconcile_margin(bad_debt_before);
+                    self.drain_forced_cancels_into_events();
+                    if matches!(solvency, Solvency::Liquidated | Solvency::Bankrupt) {
+                        core::hint::cold_path();
+                        self.liquidated_during_fills = true;
+                        return;
+                    }
                     if exhausted {
                         return;
                     }
@@ -457,14 +659,24 @@ where
         if market_update.can_fill_asks() {
             while let Some(order) = self.account.active_limit_orders().best_ask() {
                 if let Some((filled_qty, exhausted)) = market_update.limit_order_filled(order) {
+                    let bad_debt_before = self.account.balances().bad_debt();
                     let limit_order_update = self.fill_limit_order(
                         order.clone(),
                         filled_qty,
                         market_update.timestamp_exchange_ns(),
                     );
-                    self.limit_order_updates
-                        .push_within_capacity(limit_order_update)
+                    self.limit_order_events
+                        .push_within_capacity(LimitOrderEvent::Fill(limit_order_update))
                         .expect(EXPECT_CAPACITY);
+                    // A fill which reduced the position settles without a prior risk
+                    // check; the venue reconciles any collateral shortfall it caused.
+                    let solvency = self.reconcile_margin(bad_debt_before);
+                    self.drain_forced_cancels_into_events();
+                    if matches!(solvency, Solvency::Liquidated | Solvency::Bankrupt) {
+                        core::hint::cold_path();
+                        self.liquidated_during_fills = true;
+                        return;
+                    }
                     if exhausted {
                         return;
                     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,11 @@ pub mod prelude {
         account::*,
         config::Config,
         contract_specification::*,
-        exchange::Exchange,
+        exchange::{
+            Exchange,
+            ForcedCancels,
+            MarketOrderSettlement,
+        },
         leverage,
         market_state::MarketState,
         market_update::*,

--- a/src/risk_engine/isolated_margin.rs
+++ b/src/risk_engine/isolated_margin.rs
@@ -72,22 +72,12 @@ where
         account: &Account<I, D, BaseOrQuote, UserOrderIdT>,
         order: &LimitOrder<I, D, BaseOrQuote, UserOrderIdT, Pending<I, D, BaseOrQuote>>,
     ) -> Result<(), NotEnoughAvailableBalance> {
-        let om = account.order_margin();
-        let new_order_margin = account.order_margin_with_order(order);
-        let maker_fee = (*self.contract_spec.fee_maker().as_ref()).max(Zero::zero());
-        let pending_fees = account
-            .active_limit_orders()
-            .iter()
-            .fold(BaseOrQuote::PairedCurrency::zero(), |fees, order| {
-                fees + order.notional() * maker_fee
-            })
-            + order.notional() * maker_fee;
-
-        let available_balance = account.available_balance();
-        trace!(
-            "order_margin: {om:?}, new_order_margin: {new_order_margin:?}, pending_fees: {pending_fees:?}, available_balance: {available_balance:?}"
-        );
-        if new_order_margin + pending_fees > available_balance + om {
+        // Admission is decided by the canonical collateral requirement of the account:
+        // with the new order resting, the position margin, the order margin and the
+        // reserved maker fees must still be covered by the account equity.
+        let excess = account.margin_excess_with_order(order);
+        trace!("check_limit_order: margin_excess_with_order: {excess:?}");
+        if excess < Zero::zero() {
             return Err(NotEnoughAvailableBalance);
         }
 
@@ -157,7 +147,11 @@ where
             Less => {
                 let abs_qty = account.position().quantity().abs();
                 if order.quantity() <= abs_qty {
-                    // The order strictly reduces the position, so no additional margin is required.
+                    // The order strictly reduces the position, so no additional margin is required
+                    // and a risk-reducing order is never rejected. Any collateral shortfall its
+                    // settlement causes (fees, realized losses, resting orders losing their
+                    // position offset) is resolved by `Exchange::reconcile_margin`, which
+                    // force-cancels resting limit orders like a real venue's margin call.
                     return Ok(());
                 }
                 // The order reduces the short and puts on a long
@@ -214,7 +208,11 @@ where
                 let abs_qty = account.position().quantity().abs();
                 // Else its a long position which needs to be reduced
                 if order.quantity() <= abs_qty {
-                    // The order strictly reduces the position, so no additional margin is required.
+                    // The order strictly reduces the position, so no additional margin is required
+                    // and a risk-reducing order is never rejected. Any collateral shortfall its
+                    // settlement causes (fees, realized losses, resting orders losing their
+                    // position offset) is resolved by `Exchange::reconcile_margin`, which
+                    // force-cancels resting limit orders like a real venue's margin call.
                     return Ok(());
                 }
                 // The order reduces the long position and opens a short.

--- a/src/tests/cancel_limit_order.rs
+++ b/src/tests/cancel_limit_order.rs
@@ -45,9 +45,10 @@ fn cancel_limit_order() {
         exchange.account().order_margin(),
         QuoteCurrency::new(100, 0)
     );
+    // 1000 equity - 100 order margin - 0.02 reserved maker fee.
     assert_eq!(
         exchange.account().available_balance(),
-        QuoteCurrency::new(900, 0)
+        QuoteCurrency::new(89_998_000, 5)
     );
 
     exchange

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,6 +1,7 @@
 mod amend;
 mod cancel_limit_order;
 mod partial_order_fill;
+mod reduce_position_order_margin;
 mod submit_limit_buy_order;
 mod submit_limit_sell_order;
 mod submit_market_buy_order;

--- a/src/tests/partial_order_fill.rs
+++ b/src/tests/partial_order_fill.rs
@@ -54,5 +54,5 @@ fn partial_limit_order_fill(
         fee: f,
         order_after_fill: order,
     };
-    assert_eq!(exec_orders[0], expected_order_update);
+    assert_eq!(exec_orders[0], LimitOrderEvent::Fill(expected_order_update));
 }

--- a/src/tests/reduce_position_order_margin.rs
+++ b/src/tests/reduce_position_order_margin.rs
@@ -1,21 +1,30 @@
+//! A position-reducing fill is never rejected by the venue, yet settling it pays fees,
+//! may realize a loss and shrinks the position notional which offset resting reduce-side
+//! limit orders. These tests assert that the exchange reconciles the resulting collateral
+//! shortfall like a real venue: by force-cancelling resting limit orders (margin call),
+//! force-closing the position when the maintenance margin is breached and recording bad
+//! debt on bankruptcy - never by rejecting the risk-reducing order or panicking.
+
+use std::num::NonZeroU16;
+
+use const_decimal::Decimal;
+
 use crate::{
+    DECIMALS,
+    EXPECT_CONFIG,
+    EXPECT_CONTRACT_SPEC,
+    EXPECT_DECIMAL,
+    EXPECT_NON_ZERO,
+    EXPECT_QUANTITY_FILTER,
     mock_exchange_linear,
     prelude::*,
+    test_fee_maker,
+    test_fee_taker,
+    utils::NoUserOrderId,
 };
 
-/// Reproduces an accounting hole observed in downstream backtests:
-///
-/// A position-reducing market order bypasses every risk check
-/// (`check_market_sell_order` returns `Ok(())` early for `order.quantity() <= abs_qty`),
-/// yet settling it still realizes losses and pays taker fees out of the wallet, and
-/// shrinking the position strips the offset from a resting sell limit order, raising
-/// its order margin requirement. Nothing re-checks or re-reserves, so the account ends
-/// with `equity < position_margin + order_margin` and the next `available_balance`
-/// call fails its debug assertion.
-#[test]
-#[should_panic(expected = "avail >= Zero::zero()")]
-/// TODO: fix this panic
-fn reducing_market_order_violates_balance_invariant() {
+fn setup_long_with_resting_ask()
+-> Exchange<i64, DECIMALS, BaseCurrency<i64, DECIMALS>, NoUserOrderId> {
     let mut exchange = mock_exchange_linear();
     assert!(
         exchange
@@ -34,8 +43,9 @@ fn reducing_market_order_violates_balance_invariant() {
         .submit_market_order(MarketOrder::new(Side::Buy, BaseCurrency::new(97, 1)).unwrap())
         .unwrap();
 
-    // Rest a sell limit order above entry. It is almost fully offset by the long:
-    // order margin = max(0, 999.1 - 979.7) = 19.4, which passes the risk check.
+    // Rest a sell limit order above entry. It is almost fully offset by the long position:
+    // order margin max(0, 999.1 - 979.7) = 19.4 plus a maker fee reserve of 0.19982,
+    // which passes the canonical admission check.
     exchange
         .submit_limit_order(
             LimitOrder::new(
@@ -47,15 +57,272 @@ fn reducing_market_order_violates_balance_invariant() {
         )
         .unwrap();
 
-    // Partially close the long at a loss. No risk check runs for reducing orders, but:
-    // - realized pnl 4 * (100 - 101) = -4 and taker fee 0.24 shrink equity to 995.17218,
-    // - position margin drops to 575.7 while the resting ask is re-offset to
-    //   max(0, 999.1 - 575.7) = 423.4 of order margin.
-    // Total requirement 999.1 now exceeds equity: available balance is negative.
     exchange
+}
+
+/// Partially closing the long at a loss is never rejected, but it realizes a loss of 4,
+/// pays a taker fee of 0.24 and re-offsets the resting ask from 19.4 to 423.4 of order
+/// margin. The required collateral of 999.29982 then exceeds the equity of 995.17218,
+/// so the venue force-cancels the resting ask within the same settlement.
+#[test]
+fn reducing_market_order_triggers_margin_call_cancel() {
+    let mut exchange = setup_long_with_resting_ask();
+
+    let settlement = exchange
         .submit_market_order(MarketOrder::new(Side::Sell, BaseCurrency::new(4, 0)).unwrap())
         .unwrap();
 
-    // Observing the available balance now trips `debug_assert!(avail >= Zero::zero())`.
-    let _ = exchange.account().available_balance();
+    assert_eq!(settlement.solvency, Solvency::Solvent);
+    assert_eq!(settlement.forced_cancels.len(), 1);
+    assert_eq!(
+        settlement.forced_cancels[0].limit_price(),
+        QuoteCurrency::new(103, 0)
+    );
+    assert!(exchange.account().active_limit_orders().is_empty());
+    assert_eq!(
+        exchange.account().balances().equity(),
+        QuoteCurrency::new(99_517_218, 5)
+    );
+    // equity 995.17218 - position margin 575.7; observing it must not panic.
+    assert_eq!(
+        exchange.account().available_balance(),
+        QuoteCurrency::new(41_947_218, 5)
+    );
+
+    // The account is fully operational afterwards: a new limit order is accepted.
+    exchange
+        .submit_limit_order(
+            LimitOrder::new(
+                Side::Sell,
+                QuoteCurrency::new(104, 0),
+                BaseCurrency::new(57, 1),
+            )
+            .unwrap(),
+        )
+        .unwrap();
+}
+
+/// A liquidation force-cancels the resting orders first (emitting them as events),
+/// then closes the position with an internal fill which bypasses the order rate
+/// limiter and all admission checks.
+#[test]
+fn liquidation_force_cancels_resting_orders() {
+    let mut exchange = setup_long_with_resting_ask();
+
+    // Crash below the liquidation price of 101 * (1 - 0.5) = 50.5.
+    // The position is force-closed at the bid of 50:
+    // realized pnl 9.7 * (50 - 101) = -494.7, taker fee 0.291.
+    let result = exchange.update_state(&Bba {
+        bid: QuoteCurrency::new(50, 0),
+        ask: QuoteCurrency::new(51, 0),
+        timestamp_exchange_ns: 1.into(),
+    });
+    assert!(matches!(result, Err(RiskError::Liquidate)));
+
+    // The forced cancellation is observable through the event stream.
+    assert_eq!(exchange.limit_order_events().len(), 1);
+    assert!(matches!(
+        exchange.limit_order_events()[0],
+        LimitOrderEvent::ForcedCancel(_)
+    ));
+
+    assert!(exchange.account().position().quantity().is_zero());
+    assert!(exchange.account().active_limit_orders().is_empty());
+    assert_eq!(
+        exchange.account().balances().equity(),
+        QuoteCurrency::new(50_442_118, 5)
+    );
+    assert!(exchange.account().balances().bad_debt().is_zero());
+    assert_eq!(
+        exchange.account().available_balance(),
+        QuoteCurrency::new(50_442_118, 5)
+    );
+}
+
+/// The mirrored case: reducing a short position at a loss re-offsets a resting bid.
+#[test]
+fn reducing_short_market_order_triggers_margin_call_cancel() {
+    let mut exchange = mock_exchange_linear();
+    assert!(
+        exchange
+            .update_state(&Bba {
+                bid: QuoteCurrency::new(100, 0),
+                ask: QuoteCurrency::new(101, 0),
+                timestamp_exchange_ns: 0.into()
+            })
+            .unwrap()
+            .is_empty()
+    );
+
+    // Short 9.7 @ 100 -> position margin 970, taker fee 0.582, equity 999.418.
+    exchange
+        .submit_market_order(MarketOrder::new(Side::Sell, BaseCurrency::new(97, 1)).unwrap())
+        .unwrap();
+
+    // Rest a buy limit order at the entry price; fully offset by the short (order margin 0).
+    exchange
+        .submit_limit_order(
+            LimitOrder::new(
+                Side::Buy,
+                QuoteCurrency::new(100, 0),
+                BaseCurrency::new(97, 1),
+            )
+            .unwrap(),
+        )
+        .unwrap();
+
+    // The market moves against the short, but stays above the liquidation price of 150.
+    assert!(
+        exchange
+            .update_state(&Bba {
+                bid: QuoteCurrency::new(110, 0),
+                ask: QuoteCurrency::new(111, 0),
+                timestamp_exchange_ns: 1.into()
+            })
+            .unwrap()
+            .is_empty()
+    );
+
+    // Reduce the short by 4 @ 111: realized pnl 4 * (100 - 111) = -44, taker fee 0.2664,
+    // equity 955.1516. The resting bid is re-offset from 0 to 400 of order margin, so the
+    // required collateral of 970.194 exceeds the equity and the bid is cancelled.
+    let settlement = exchange
+        .submit_market_order(MarketOrder::new(Side::Buy, BaseCurrency::new(4, 0)).unwrap())
+        .unwrap();
+
+    assert_eq!(settlement.solvency, Solvency::Solvent);
+    assert_eq!(settlement.forced_cancels.len(), 1);
+    assert!(exchange.account().active_limit_orders().is_empty());
+    assert_eq!(
+        exchange.account().balances().equity(),
+        QuoteCurrency::new(95_515_160, 5)
+    );
+    // equity 955.1516 - position margin 570; observing it must not panic.
+    assert_eq!(
+        exchange.account().available_balance(),
+        QuoteCurrency::new(38_515_160, 5)
+    );
+}
+
+/// The margin call cancels the largest collateral contributor first,
+/// so as few orders as possible are cancelled.
+#[test]
+fn margin_call_cancels_largest_order_first() {
+    let mut exchange = mock_exchange_linear();
+    assert!(
+        exchange
+            .update_state(&Bba {
+                bid: QuoteCurrency::new(100, 0),
+                ask: QuoteCurrency::new(101, 0),
+                timestamp_exchange_ns: 0.into()
+            })
+            .unwrap()
+            .is_empty()
+    );
+    exchange
+        .submit_market_order(MarketOrder::new(Side::Buy, BaseCurrency::new(97, 1)).unwrap())
+        .unwrap();
+
+    // Two resting asks with a combined notional of 999.1, as in the single-order case.
+    exchange
+        .submit_limit_order(
+            LimitOrder::new(
+                Side::Sell,
+                QuoteCurrency::new(103, 0),
+                BaseCurrency::new(5, 0),
+            )
+            .unwrap(),
+        )
+        .unwrap();
+    exchange
+        .submit_limit_order(
+            LimitOrder::new(
+                Side::Sell,
+                QuoteCurrency::new(103, 0),
+                BaseCurrency::new(47, 1),
+            )
+            .unwrap(),
+        )
+        .unwrap();
+
+    // The same reducing order as in `reducing_market_order_triggers_margin_call_cancel`:
+    // cancelling the larger ask (notional 515) covers the shortfall on its own.
+    let settlement = exchange
+        .submit_market_order(MarketOrder::new(Side::Sell, BaseCurrency::new(4, 0)).unwrap())
+        .unwrap();
+
+    assert_eq!(settlement.solvency, Solvency::Solvent);
+    assert_eq!(settlement.forced_cancels.len(), 1);
+    assert_eq!(
+        settlement.forced_cancels[0].remaining_quantity(),
+        BaseCurrency::new(5, 0)
+    );
+    // The smaller ask survives as it is fully offset by the remaining position.
+    let surviving: Vec<_> = exchange.account().active_limit_orders().iter().collect();
+    assert_eq!(surviving.len(), 1);
+    assert_eq!(surviving[0].remaining_quantity(), BaseCurrency::new(47, 1));
+    // equity 995.17218 - position margin 575.7 - fee reserve 0.09682 of the survivor.
+    assert_eq!(
+        exchange.account().available_balance(),
+        QuoteCurrency::new(41_937_536, 5)
+    );
+}
+
+/// A leveraged position liquidated after the market gapped through its bankruptcy price
+/// realizes a loss larger than the account equity. The venue absorbs the excess as bad
+/// debt instead of panicking, mirroring a real insurance fund.
+#[test]
+fn gapped_liquidation_records_bad_debt_without_panicking() {
+    let contract_spec = ContractSpecification::new(
+        leverage!(5),
+        Decimal::try_from_scaled(5, 1).expect(EXPECT_DECIMAL),
+        PriceFilter::default(),
+        QuantityFilter::new(None, None, BaseCurrency::new(1, 2)).expect(EXPECT_QUANTITY_FILTER),
+        test_fee_maker(),
+        test_fee_taker(),
+    )
+    .expect(EXPECT_CONTRACT_SPEC);
+    let config = Config::new(
+        QuoteCurrency::new(1000, 0),
+        NonZeroU16::new(10).expect(EXPECT_NON_ZERO),
+        contract_spec,
+        OrderRateLimits::default(),
+    )
+    .expect(EXPECT_CONFIG);
+    let mut exchange =
+        Exchange::<i64, DECIMALS, BaseCurrency<i64, DECIMALS>, NoUserOrderId>::new(config);
+
+    assert!(
+        exchange
+            .update_state(&Bba {
+                bid: QuoteCurrency::new(100, 0),
+                ask: QuoteCurrency::new(101, 0),
+                timestamp_exchange_ns: 0.into()
+            })
+            .unwrap()
+            .is_empty()
+    );
+
+    // Long 40 @ 101 at 5x leverage: position margin 808, taker fee 2.424, equity 997.576.
+    exchange
+        .submit_market_order(MarketOrder::new(Side::Buy, BaseCurrency::new(40, 0)).unwrap())
+        .unwrap();
+
+    // The market gaps far below the liquidation price of 101 * (1 - 0.1) = 90.9.
+    // Closing 40 @ 70 realizes a pnl of -1240, exceeding the equity of 997.576:
+    // 242.424 of the loss plus the 1.68 liquidation fee become bad debt.
+    let result = exchange.update_state(&Bba {
+        bid: QuoteCurrency::new(70, 0),
+        ask: QuoteCurrency::new(71, 0),
+        timestamp_exchange_ns: 1.into(),
+    });
+    assert!(matches!(result, Err(RiskError::Liquidate)));
+
+    assert!(exchange.account().position().quantity().is_zero());
+    assert!(exchange.account().balances().equity().is_zero());
+    assert_eq!(
+        exchange.account().balances().bad_debt(),
+        QuoteCurrency::new(24_410_400, 5)
+    );
+    assert!(exchange.account().available_balance().is_zero());
 }

--- a/src/tests/reduce_position_order_margin.rs
+++ b/src/tests/reduce_position_order_margin.rs
@@ -1,0 +1,61 @@
+use crate::{
+    mock_exchange_linear,
+    prelude::*,
+};
+
+/// Reproduces an accounting hole observed in downstream backtests:
+///
+/// A position-reducing market order bypasses every risk check
+/// (`check_market_sell_order` returns `Ok(())` early for `order.quantity() <= abs_qty`),
+/// yet settling it still realizes losses and pays taker fees out of the wallet, and
+/// shrinking the position strips the offset from a resting sell limit order, raising
+/// its order margin requirement. Nothing re-checks or re-reserves, so the account ends
+/// with `equity < position_margin + order_margin` and the next `available_balance`
+/// call fails its debug assertion.
+#[test]
+#[should_panic(expected = "avail >= Zero::zero()")]
+/// TODO: fix this panic
+fn reducing_market_order_violates_balance_invariant() {
+    let mut exchange = mock_exchange_linear();
+    assert!(
+        exchange
+            .update_state(&Bba {
+                bid: QuoteCurrency::new(100, 0),
+                ask: QuoteCurrency::new(101, 0),
+                timestamp_exchange_ns: 0.into()
+            })
+            .unwrap()
+            .is_empty()
+    );
+
+    // Open a long position with almost the entire wallet:
+    // 9.7 @ 101 -> position margin 979.7, taker fee 0.58782, equity 999.41218.
+    exchange
+        .submit_market_order(MarketOrder::new(Side::Buy, BaseCurrency::new(97, 1)).unwrap())
+        .unwrap();
+
+    // Rest a sell limit order above entry. It is almost fully offset by the long:
+    // order margin = max(0, 999.1 - 979.7) = 19.4, which passes the risk check.
+    exchange
+        .submit_limit_order(
+            LimitOrder::new(
+                Side::Sell,
+                QuoteCurrency::new(103, 0),
+                BaseCurrency::new(97, 1),
+            )
+            .unwrap(),
+        )
+        .unwrap();
+
+    // Partially close the long at a loss. No risk check runs for reducing orders, but:
+    // - realized pnl 4 * (100 - 101) = -4 and taker fee 0.24 shrink equity to 995.17218,
+    // - position margin drops to 575.7 while the resting ask is re-offset to
+    //   max(0, 999.1 - 575.7) = 423.4 of order margin.
+    // Total requirement 999.1 now exceeds equity: available balance is negative.
+    exchange
+        .submit_market_order(MarketOrder::new(Side::Sell, BaseCurrency::new(4, 0)).unwrap())
+        .unwrap();
+
+    // Observing the available balance now trips `debug_assert!(avail >= Zero::zero())`.
+    let _ = exchange.account().available_balance();
+}

--- a/src/tests/submit_limit_buy_order.rs
+++ b/src/tests/submit_limit_buy_order.rs
@@ -38,9 +38,10 @@ fn submit_limit_buy_order_no_position() {
         exchange.account().order_margin(),
         QuoteCurrency::new(490, 0)
     );
+    // 1000 equity - 490 order margin - 0.098 reserved maker fee.
     assert_eq!(
         exchange.account().available_balance(),
-        QuoteCurrency::new(510, 0)
+        QuoteCurrency::new(50_990_200, 5)
     );
 
     // Now fill the order
@@ -57,11 +58,11 @@ fn submit_limit_buy_order_no_position() {
                 timestamp_exchange_ns: 0.into()
             })
             .unwrap(),
-        &vec![LimitOrderFill::FullyFilled {
+        &vec![LimitOrderEvent::Fill(LimitOrderFill::FullyFilled {
             filled_quantity: BaseCurrency::new(5, 0),
             fee,
             order_after_fill: order.into_filled(0.into()),
-        }]
+        })]
     );
     let bid = QuoteCurrency::new(96, 0);
     let ask = QuoteCurrency::new(99, 0);
@@ -120,9 +121,11 @@ fn submit_limit_buy_order_no_position() {
         exchange.account().position_margin(),
         QuoteCurrency::new(490, 0)
     );
+    // The resting sell order is fully offset by the long position (zero order margin)
+    // but still reserves its own maker fee, which happens to equal `fee`.
     assert_eq!(
         exchange.account().available_balance(),
-        QuoteCurrency::new(510, 0) - fee
+        QuoteCurrency::new(510, 0) - fee - fee
     );
     assert!(exchange.account().order_margin().is_zero());
 
@@ -151,11 +154,11 @@ fn submit_limit_buy_order_no_position() {
                 timestamp_exchange_ns: 3.into()
             })
             .unwrap(),
-        &vec![LimitOrderFill::FullyFilled {
+        &vec![LimitOrderEvent::Fill(LimitOrderFill::FullyFilled {
             filled_quantity: BaseCurrency::new(5, 0),
             fee,
             order_after_fill: order.into_filled(3.into())
-        }]
+        })]
     );
     assert_eq!(exchange.account().position(), &Position::default());
     assert_eq!(
@@ -325,11 +328,11 @@ fn submit_limit_buy_order_with_long() {
                 timestamp_exchange_ns: 2.into()
             })
             .unwrap(),
-        &vec![LimitOrderFill::FullyFilled {
+        &vec![LimitOrderEvent::Fill(LimitOrderFill::FullyFilled {
             filled_quantity: BaseCurrency::new(9, 0),
             fee,
             order_after_fill: order.into_filled(2.into())
-        }]
+        })]
     );
 
     assert_eq!(exchange.account().position(), &Position::default());
@@ -410,11 +413,11 @@ fn submit_limit_buy_order_with_short() {
                 timestamp_exchange_ns: 1.into(),
             })
             .unwrap(),
-        &vec![LimitOrderFill::FullyFilled {
+        &vec![LimitOrderEvent::Fill(LimitOrderFill::FullyFilled {
             filled_quantity: BaseCurrency::new(9, 0),
             fee,
             order_after_fill: order.into_filled(1.into())
-        }]
+        })]
     );
 
     assert_eq!(exchange.account().position(), &Position::default());

--- a/src/tests/submit_limit_sell_order.rs
+++ b/src/tests/submit_limit_sell_order.rs
@@ -40,11 +40,11 @@ fn submit_limit_sell_order_no_position() {
                 timestamp_exchange_ns: 1.into()
             })
             .unwrap(),
-        &vec![LimitOrderFill::FullyFilled {
+        &vec![LimitOrderEvent::Fill(LimitOrderFill::FullyFilled {
             filled_quantity: BaseCurrency::new(9, 0),
             fee,
             order_after_fill: order.into_filled(1.into())
-        }]
+        })]
     );
     exchange
         .update_state(&Bba {
@@ -100,11 +100,11 @@ fn submit_limit_sell_order_no_position() {
                 timestamp_exchange_ns: 3.into(),
             })
             .unwrap(),
-        &vec![LimitOrderFill::FullyFilled {
+        &vec![LimitOrderEvent::Fill(LimitOrderFill::FullyFilled {
             filled_quantity: BaseCurrency::new(9, 0),
             fee: fee1,
             order_after_fill: order.into_filled(3.into()),
-        }]
+        })]
     );
     assert_eq!(exchange.account().position(), &Position::default());
     assert_eq!(

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -11,6 +11,7 @@ mod order_update;
 mod re_pricing;
 mod side;
 mod smol_currency;
+mod solvency;
 mod timestamp_ns;
 
 pub use errors::*;
@@ -31,7 +32,10 @@ pub use order_status::{
     NewOrder,
     Pending,
 };
-pub use order_update::LimitOrderFill;
+pub use order_update::{
+    LimitOrderEvent,
+    LimitOrderFill,
+};
 pub use re_pricing::RePricing;
 pub use side::Side;
 pub use smol_currency::{
@@ -41,6 +45,7 @@ pub use smol_currency::{
     Mon,
     QuoteCurrency,
 };
+pub use solvency::Solvency;
 pub(crate) use timestamp_ns::NANOS_PER_SECOND;
 pub use timestamp_ns::TimestampNs;
 

--- a/src/types/order_update.rs
+++ b/src/types/order_update.rs
@@ -9,6 +9,21 @@ use super::{
     UserOrderId,
 };
 
+/// An event concerning a resting limit order, emitted by `Exchange::update_state`.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum LimitOrderEvent<I, const D: u8, BaseOrQuote, UserOrderIdT>
+where
+    I: Mon<D> + Display,
+    BaseOrQuote: Currency<I, D> + Display,
+    UserOrderIdT: UserOrderId + Display,
+{
+    /// The resting order was partially or fully filled.
+    Fill(LimitOrderFill<I, D, BaseOrQuote, UserOrderIdT>),
+    /// The venue force-cancelled the resting order to keep the account's required
+    /// collateral covered by its equity after a fill or liquidation (margin call).
+    ForcedCancel(LimitOrder<I, D, BaseOrQuote, UserOrderIdT, Pending<I, D, BaseOrQuote>>),
+}
+
 /// Contains the possible updates to limit orders.
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum LimitOrderFill<I, const D: u8, BaseOrQuote, UserOrderIdT>

--- a/src/types/solvency.rs
+++ b/src/types/solvency.rs
@@ -1,0 +1,21 @@
+/// The solvency of the account after a fill was settled and the collateral reconciled.
+///
+/// A position-reducing fill is never rejected by the venue, so settling it can leave the
+/// account with less equity than its required collateral. The exchange then reconciles
+/// the account like a real venue would and reports the outcome through this type.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Solvency {
+    /// The account equity covers the required collateral.
+    Solvent,
+    /// The equity does not cover the position's initial margin requirement even after
+    /// force-cancelling every resting order. No new risk-increasing orders will be
+    /// admitted (the available balance is zero), but the position is kept as long as
+    /// it satisfies the maintenance margin.
+    InitialMarginDeficit,
+    /// The equity fell below the position's maintenance margin requirement;
+    /// the resting orders were cancelled and the position was force-closed.
+    Liquidated,
+    /// Realized losses exhausted the account equity entirely; the excess loss is
+    /// absorbed by the venue and recorded as `Balances::bad_debt`.
+    Bankrupt,
+}

--- a/tests/inverse_futures.rs
+++ b/tests/inverse_futures.rs
@@ -913,9 +913,10 @@ fn inv_execute_limit() {
     );
     assert!(exchange.account().position_margin().is_zero());
     assert_eq!(exchange.account().order_margin(), BaseCurrency::new(5, 1));
+    // 1 equity - 0.5 order margin - 0.0001 reserved maker fee.
     assert_eq!(
         exchange.account().available_balance(),
-        BaseCurrency::new(5, 1)
+        BaseCurrency::new(49_990, 5)
     );
 
     let order_updates = exchange
@@ -1020,9 +1021,10 @@ fn inv_execute_limit() {
     );
     assert!(exchange.account().position_margin().is_zero());
     assert_eq!(exchange.account().order_margin(), BaseCurrency::new(5, 1));
+    // The resting sell order additionally reserves its own maker fee `fee_2`.
     assert_eq!(
         exchange.account().available_balance(),
-        BaseCurrency::new(55, 2) - fee_0 - fee_1
+        BaseCurrency::new(55, 2) - fee_0 - fee_1 - fee_2
     );
 
     let order_updates = exchange

--- a/tests/limit_orders_only.rs
+++ b/tests/limit_orders_only.rs
@@ -46,9 +46,10 @@ fn limit_orders_only() {
         exchange.account().order_margin(),
         QuoteCurrency::new(950, 0)
     );
+    // 1000 equity - 950 order margin - 0.19 reserved maker fee.
     assert_eq!(
         exchange.account().available_balance(),
-        QuoteCurrency::new(50, 0)
+        QuoteCurrency::new(4_981_000, 5)
     );
 
     let order_updates = exchange


### PR DESCRIPTION
Changes:
- version `0.138.0`
- Fixed previous panic asserting `available_balance >= 0`, which was violated after a risk-reducing market order got filled and margin was no longer sufficient.
- New method `reconcile_margin` ensures account collateral is reconciled after a fill was settled.
- `liquidate` refactored into `force_liquidate`, avoiding possible panic paths by not going through public interface with additional checks.
- New types `ForcedCancels`, `Solvency` and `MarketOrderSettlement` to ensure forced cancels of limit orders are propagated nicely through the public API.
- Bunch more new methods on `Account` to help with everything.
- `Account` gained a `bad_debt` field of losses absorbed by the venue (insurance fund / auto-deleveraging style)
- Now position reducing orders are always accepted by the venue (as before), but the panicking assumptions are eliminated.